### PR TITLE
Add Inline Comment snippet with whitespace control

### DIFF
--- a/vscode-dbt/snippets/snippets.json
+++ b/vscode-dbt/snippets/snippets.json
@@ -15,6 +15,13 @@
         ],
         "description": "Inline Block"
     },
+    "Comment": {
+        "prefix": "comment",
+        "body": [
+            "{#- $1 -#}"
+        ],
+        "description": "Inline Comment"
+    },
     "Complete Variable": {
         "prefix": "cvar",
         "body": [


### PR DESCRIPTION
Whitespace control included since Jinja dbt comments do not produce anything but whitespace when compiled