### PR TITLE
Feature: add snippet for model description

### DIFF
--- a/images/model_overview.gif
+++ b/images/model_overview.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ff4b3fdb5fe588d935cd459976827efa51de14db69705763ec78fdf9901f83
+size 2569724

--- a/vscode-dbt/README.md
+++ b/vscode-dbt/README.md
@@ -14,6 +14,9 @@ Cool Tip: For a richer integration between dbt and vscode you should install [vs
 `ref`, `source`, `log`, `config` etc. See [source](./vscode-dbt/snippets/snippets_sql.json) for a full list.
 ![dbt_sql](../images/dbt_sql.gif)
 
+![model_overview](../images/model_overview.gif)
+This snippet helps coders provide a high-level overview of every model in a standard way.
+
 ### YAML
 `ref`, `source`, `var` etc. See [source](./vscode-dbt/snippets/snippets_yaml.json) for a full list.
 

--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -133,16 +133,17 @@
         ],
         "description": "Env Var"
     },
-    "Model Description": {
-        "prefix": "model_description",
+    "Model Overview": {
+        "prefix": "model_overview",
         "body": [
             "{#-",
             "Goal: ${1:high-level objective of the model}",
             "Granularity: ${2:level of detail of the model}",
-            "Assumptions: ${3:assumptions if any}",
+            "Assumptions/Caveats:",
+            "   - ${3:assumptions/caveats if any}",
             "-#}"
         ],
-        "description": "Model Description"
+        "description": "Model Overview"
     },
     "Load Result": {
         "prefix": "load_result",

--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -133,6 +133,17 @@
         ],
         "description": "Env Var"
     },
+    "Model Description": {
+        "prefix": "model_description",
+        "body": [
+            "{#-",
+            "Goal: $(1:high-level objective of the model)",
+            "Granularity: $(2:level of detail of the model)",
+            "Assumptions: $(3:assumptions if any)",
+            "-#}"
+        ],
+        "description": "Model Description"
+    },
     "Load Result": {
         "prefix": "load_result",
         "body": [

--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -137,9 +137,9 @@
         "prefix": "model_description",
         "body": [
             "{#-",
-            "Goal: $(1:high-level objective of the model)",
-            "Granularity: $(2:level of detail of the model)",
-            "Assumptions: $(3:assumptions if any)",
+            "Goal: ${1:high-level objective of the model}",
+            "Granularity: ${2:level of detail of the model}",
+            "Assumptions: ${3:assumptions if any}",
             "-#}"
         ],
         "description": "Model Description"

--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -140,7 +140,7 @@
             "Goal: ${1:high-level objective of the model}",
             "Granularity: ${2:level of detail of the model}",
             "Assumptions/Caveats:",
-            "   - ${3:assumptions/caveats if any}",
+            "   ${3:- assumptions/caveats if any}",
             "-#}"
         ],
         "description": "Model Overview"


### PR DESCRIPTION
This PR is intended to add a small snippet to help users provide a high-level description of their dbt model (goal, granularity, assumptions/known caveats, etc).

While I like the idea, and see the value, I wonder how to make it most useful for the end-user. As such, I'm concerned there is too much text

UI Looks like:
![model_overview](https://user-images.githubusercontent.com/10062018/106393672-cb5f6d00-63f8-11eb-8cdc-338d0bfab1ef.gif)
