### PR TITLE
Add snapshot snippet

### DIFF
--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -103,6 +103,31 @@
             "{% endset %}"
         ]
     },
+    "Snapshot": {
+        "prefix": [
+            "snapshot",
+            "snap"
+        ],
+        "body": [
+            "{% snapshot ${1:snapshot_name} %}",
+            "",
+            "{{",
+            "   config(",
+            "       target_database='${2:target_database}',",
+            "       target_schema='${3:target_schema}',",
+            "       unique_key='${4:unique_key}',",
+            "",
+            "       strategy='${5:strategy}',",
+            "       updated_at='${6:updated_at}',",
+            "   )",
+            "}}",
+            "",
+            "select * from ${7: -- source or ref}",
+            "",
+            "{% endsnapshot %}"
+        ],
+        "description": "Dbt snapshot"
+    },
     "Dbt Config Block": {
         "prefix": "config",
         "body": [

--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -122,7 +122,6 @@
             "   )",
             "}}",
             "",
-            "select * from ${7: -- source or ref}",
             "",
             "{% endsnapshot %}"
         ],


### PR DESCRIPTION
Add snapshot snippet according to base snapshot config found in [Snapshot | dbt Docs](https://docs.getdbt.com/docs/building-a-dbt-project/snapshots).

## Usage
User will type in either `snap` or `snapshot` to trigger snippet. Then the user will tab through 6 config options to fill out the snapshot config which will look like:

```sql
{% snapshot snapshot_name %}

{{
    config(
        target_database='target_database',
        target_schema='target_schema',
        unique_key='unique_key',

        strategy='strategy',
        updated_at='updated_at',
    )
}}


{% endsnapshot %}
```