### PR TITLE
add snippet for logging a var's name and value

### DIFF
--- a/vscode-dbt/snippets/snippets_sql.json
+++ b/vscode-dbt/snippets/snippets_sql.json
@@ -159,6 +159,13 @@
         ],
         "description": "Log"
     },
+    "Log a variable": {
+        "prefix": "log_var",
+        "body": [
+            "{{ log('${1:var}: ' ~ ${1:var}, info=${2|True,False|}) }}"
+        ],
+        "description": "Log a single variable's name and value"
+    },
     "Statement": {
         "prefix": "statement",
         "body": [


### PR DESCRIPTION
in Python 3.8+ I'm now very dependent on the f-string walrus-operator move:
```
> foo = 'my string'
> print(f'{foo=}')
foo='my string'
```

I find myself doing be below in Jinja all the time and missing my Pythonic way of doing it. A snippet would is the lowest-hanging fruit, although I'd love a `log_var()` macro in dbt, someday!
```
{{ log('drop_script: ' ~ drop_script, info=True) }}
```

